### PR TITLE
Allow frontend to subscribe to more events so we can make a sexier demo UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Layercode",
   "license": "MIT",
   "name": "@layercode/js-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Layercode JavaScript SDK for browser usage",
   "type": "module",
   "main": "dist/layercode-js-sdk.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ class LayercodeClient implements ILayercodeClient {
     const vadOptions: any = {
       stream: this.wavRecorder.getStream() || undefined,
       onSpeechStart: () => {
-        console.log('onSpeechStart: sending vad_start');
+        console.debug('onSpeechStart: sending vad_start');
         this.userIsSpeaking = true;
         this.options.onUserIsSpeakingChange(true);
         this._wsSend({
@@ -202,7 +202,7 @@ class LayercodeClient implements ILayercodeClient {
         });
       },
       onSpeechEnd: () => {
-        console.log('onSpeechEnd: sending vad_end');
+        console.debug('onSpeechEnd: sending vad_end');
         this.userIsSpeaking = false;
         this.options.onUserIsSpeakingChange(false);
         this.audioBuffer = []; // Clear buffer on speech end
@@ -269,7 +269,7 @@ class LayercodeClient implements ILayercodeClient {
    * Handles when agent audio finishes playing
    */
   private _clientResponseAudioReplayFinished(): void {
-    console.log('clientResponseAudioReplayFinished');
+    console.debug('clientResponseAudioReplayFinished');
     this._wsSend({
       type: 'trigger.response.audio.replay_finished',
       reason: 'completed',
@@ -322,20 +322,18 @@ class LayercodeClient implements ILayercodeClient {
     try {
       const message: ServerMessage = JSON.parse(event.data);
       if (message.type !== 'response.audio') {
-        console.log('received ws msg:', message);
+        console.log('msg:', message);
       }
 
       switch (message.type) {
         case 'turn.start':
           // Sent from the server to this client when a new user turn is detected
-          console.log('received turn.start from server');
-          console.log(message);
           if (message.role === 'assistant') {
             // Start tracking new assistant turn
-            console.log('Assistant turn started, will track new turn ID from audio/text');
+            console.debug('Assistant turn started, will track new turn ID from audio/text');
           } else if (message.role === 'user' && !this.pushToTalkEnabled) {
             // Interrupt any playing assistant audio if this is a turn triggered by the server (and not push to talk, which will have already called interrupt)
-            console.log('interrupting assistant audio, as user turn has started and pushToTalkEnabled is false');
+            console.debug('interrupting assistant audio, as user turn has started and pushToTalkEnabled is false');
             await this._clientInterruptAssistantReplay();
           }
           this.options.onMessage(message);
@@ -348,7 +346,7 @@ class LayercodeClient implements ILayercodeClient {
           // TODO: once we've added turn_id to the turn.start msgs sent from teh server, we should move this currentTurnId switching logic to the turn.start msg case. Note, setting the currentTurnId to the turnId must happen after _clientInterruptAssistantReplay is called, because that requires the old turnId to send along with the interruption event. We can then remove the currentTurnId setting logic from the response.audio and response.text cases.
           // Set current turn ID from first audio message, or update if different turn
           if (!this.currentTurnId || this.currentTurnId !== message.turn_id) {
-            console.log(`Setting current turn ID to: ${message.turn_id} (was: ${this.currentTurnId})`);
+            console.debug(`Setting current turn ID to: ${message.turn_id} (was: ${this.currentTurnId})`);
             this.currentTurnId = message.turn_id;
 
             // Clean up interrupted tracks, keeping only the current turn
@@ -360,18 +358,17 @@ class LayercodeClient implements ILayercodeClient {
           // Set turn ID from first text message if not set
           if (!this.currentTurnId) {
             this.currentTurnId = message.turn_id;
-            console.log(`Setting current turn ID to: ${message.turn_id} from text message`);
+            console.debug(`Setting current turn ID to: ${message.turn_id} from text message`);
           }
           this.options.onMessage(message);
           break;
 
         case 'response.data':
-          console.log('received response.data', message);
           this.options.onDataMessage(message);
           break;
 
         case 'user.transcript':
-          console.log('received user.transcript', message);
+        case 'user.transcript.delta':
           this.options.onMessage(message);
           break;
 
@@ -409,7 +406,7 @@ class LayercodeClient implements ILayercodeClient {
       if (sendAudio) {
         // If we have buffered audio and we're gating, send it first
         if (shouldGateAudio && this.audioBuffer.length > 0) {
-          console.log(`Sending ${this.audioBuffer.length} buffered audio chunks`);
+          console.debug(`Sending ${this.audioBuffer.length} buffered audio chunks`);
           for (const bufferedAudio of this.audioBuffer) {
             this._wsSend({
               type: 'client.audio',
@@ -441,7 +438,7 @@ class LayercodeClient implements ILayercodeClient {
 
   private _wsSend(message: ClientMessage): void {
     if (message.type !== 'client.audio') {
-      console.log('sent ws msg:', message);
+      console.debug('sent_msg:', message);
     }
     const messageString = JSON.stringify(message);
     if (this.ws?.readyState === WebSocket.OPEN) {
@@ -523,7 +520,7 @@ class LayercodeClient implements ILayercodeClient {
         })}`
       );
       const config: AgentConfig = authorizeSessionResponseBody.config;
-      console.log('config', config);
+      console.log('AgentConfig', config);
 
       // Store VAD configuration
       this.vadConfig = config.vad || null;
@@ -576,7 +573,7 @@ class LayercodeClient implements ILayercodeClient {
 
   private _resetTurnTracking(): void {
     this.currentTurnId = null;
-    console.log('Reset turn tracking state');
+    console.debug('Reset turn tracking state');
   }
 
   async disconnect(): Promise<void> {
@@ -625,11 +622,11 @@ class LayercodeClient implements ILayercodeClient {
       // Reinitialize VAD with the new audio stream if VAD is enabled
       const shouldUseVAD = !this.pushToTalkEnabled && this.vadConfig?.enabled !== false;
       if (shouldUseVAD) {
-        console.log('Reinitializing VAD with new audio stream');
+        console.debug('Reinitializing VAD with new audio stream');
         const newStream = this.wavRecorder.getStream();
         await this._reinitializeVAD(newStream);
       }
-      console.log(`Successfully switched to input device: ${deviceId}`);
+      console.debug(`Successfully switched to input device: ${deviceId}`);
     } catch (error) {
       console.error(`Failed to switch to input device ${deviceId}:`, error);
       throw new Error(`Failed to switch to input device: ${error instanceof Error ? error.message : String(error)}`);
@@ -641,7 +638,7 @@ class LayercodeClient implements ILayercodeClient {
    */
   private async _restartAudioRecording(): Promise<void> {
     try {
-      console.log('Restarting audio recording after device switch...');
+      console.debug('Restarting audio recording after device switch...');
       try {
         await this.wavRecorder.end();
       } catch {
@@ -655,7 +652,7 @@ class LayercodeClient implements ILayercodeClient {
       // Re-setup amplitude monitoring with the new stream
       this._setupAmplitudeMonitoring(this.wavRecorder, this.options.onUserAmplitudeChange, (amp) => (this.userAudioAmplitude = amp));
 
-      console.log('Audio recording restart completed successfully');
+      console.debug('Audio recording restart completed successfully');
     } catch (error) {
       console.error('Error restarting audio recording after device switch:', error);
       this.options.onError(error instanceof Error ? error : new Error(String(error)));
@@ -687,7 +684,7 @@ class LayercodeClient implements ILayercodeClient {
       try {
         const currentDeviceExists = devices.some((device: any) => device.deviceId === this.deviceId);
         if (!currentDeviceExists) {
-          console.log('Current device disconnected, switching to next available device');
+          console.debug('Current device disconnected, switching to next available device');
           try {
             const nextDevice = devices.find((d: any) => d.default);
             if (nextDevice) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class LayercodeClient implements ILayercodeClient {
       onUserIsSpeakingChange: options.onUserIsSpeakingChange || (() => {}),
     };
 
-    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 10;
+    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 20;
     this._websocketUrl = 'wss://api.layercode.com/v1/agents/web/websocket';
 
     this.wavRecorder = new WavRecorder({ sampleRate: 8000 }); // TODO should be set my fetched agent config

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,26 +277,7 @@ class LayercodeClient implements ILayercodeClient {
   }
 
   private async _clientInterruptAssistantReplay(): Promise<void> {
-    const offsetData = await this.wavPlayer.interrupt();
-
-    if (offsetData && this.currentTurnId) {
-      let offsetMs = offsetData.currentTime * 1000;
-
-      // Send interruption event with accurate playback offset in milliseconds
-      this._wsSend({
-        type: 'trigger.response.audio.interrupted',
-        playback_offset: offsetMs,
-        interruption_context: {
-          turn_id: this.currentTurnId,
-          playback_offset_ms: offsetMs,
-        },
-      } as ClientTriggerResponseAudioInterruptedMessage);
-    } else {
-      console.warn('Interruption requested but missing required data:', {
-        hasOffsetData: !!offsetData,
-        hasTurnId: !!this.currentTurnId,
-      });
-    }
+    await this.wavPlayer.interrupt();
   }
 
   async triggerUserTurnStarted(): Promise<void> {
@@ -343,7 +324,7 @@ class LayercodeClient implements ILayercodeClient {
           const audioBuffer = base64ToArrayBuffer(message.content);
           this.wavPlayer.add16BitPCM(audioBuffer, message.turn_id);
 
-          // TODO: once we've added turn_id to the turn.start msgs sent from teh server, we should move this currentTurnId switching logic to the turn.start msg case. Note, setting the currentTurnId to the turnId must happen after _clientInterruptAssistantReplay is called, because that requires the old turnId to send along with the interruption event. We can then remove the currentTurnId setting logic from the response.audio and response.text cases.
+          // TODO: once we've added turn_id to the turn.start msgs sent from teh server, we should move this currentTurnId switching logic to the turn.start msg case. We can then remove the currentTurnId setting logic from the response.audio and response.text cases.
           // Set current turn ID from first audio message, or update if different turn
           if (!this.currentTurnId || this.currentTurnId !== message.turn_id) {
             console.debug(`Setting current turn ID to: ${message.turn_id} (was: ${this.currentTurnId})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class LayercodeClient implements ILayercodeClient {
       onUserIsSpeakingChange: options.onUserIsSpeakingChange || (() => {}),
     };
 
-    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 5;
+    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 2;
     this._websocketUrl = 'wss://api.layercode.com/v1/agents/web/websocket';
 
     this.wavRecorder = new WavRecorder({ sampleRate: 8000 }); // TODO should be set my fetched agent config

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class LayercodeClient implements ILayercodeClient {
       onUserIsSpeakingChange: options.onUserIsSpeakingChange || (() => {}),
     };
 
-    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 20;
+    this.AMPLITUDE_MONITORING_SAMPLE_RATE = 5;
     this._websocketUrl = 'wss://api.layercode.com/v1/agents/web/websocket';
 
     this.wavRecorder = new WavRecorder({ sampleRate: 8000 }); // TODO should be set my fetched agent config

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ class LayercodeClient implements ILayercodeClient {
     try {
       const message: ServerMessage = JSON.parse(event.data);
       if (message.type !== 'response.audio') {
-        console.log('msg:', message);
+        console.debug('msg:', message);
       }
 
       switch (message.type) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ interface LayercodeClientOptions {
   onDeviceSwitched?: (deviceId: string) => void;
   /** Callback for data messages */
   onDataMessage?: (message: any) => void;
+  /** Callback for other messages (excluding audio msgs) */
+  onMessage?: (message: any) => void;
   /** Callback for user audio amplitude changes */
   onUserAmplitudeChange?: (amplitude: number) => void;
   /** Callback for agent audio amplitude changes */
@@ -130,6 +132,7 @@ class LayercodeClient implements ILayercodeClient {
       onError: options.onError || (() => {}),
       onDeviceSwitched: options.onDeviceSwitched || (() => {}),
       onDataMessage: options.onDataMessage || (() => {}),
+      onMessage: options.onMessage || (() => {}),
       onUserAmplitudeChange: options.onUserAmplitudeChange || (() => {}),
       onAgentAmplitudeChange: options.onAgentAmplitudeChange || (() => {}),
       onStatusChange: options.onStatusChange || (() => {}),
@@ -193,6 +196,10 @@ class LayercodeClient implements ILayercodeClient {
           type: 'vad_events',
           event: 'vad_start',
         } as ClientVadEventsMessage);
+        this.options.onMessage({
+          type: 'vad_events',
+          event: 'vad_start',
+        });
       },
       onSpeechEnd: () => {
         console.log('onSpeechEnd: sending vad_end');
@@ -203,6 +210,10 @@ class LayercodeClient implements ILayercodeClient {
           type: 'vad_events',
           event: 'vad_end',
         } as ClientVadEventsMessage);
+        this.options.onMessage({
+          type: 'vad_events',
+          event: 'vad_end',
+        });
       },
     };
 
@@ -327,6 +338,7 @@ class LayercodeClient implements ILayercodeClient {
             console.log('interrupting assistant audio, as user turn has started and pushToTalkEnabled is false');
             await this._clientInterruptAssistantReplay();
           }
+          this.options.onMessage(message);
           break;
 
         case 'response.audio':
@@ -344,21 +356,27 @@ class LayercodeClient implements ILayercodeClient {
           }
           break;
 
-        case 'response.text': {
+        case 'response.text':
           // Set turn ID from first text message if not set
           if (!this.currentTurnId) {
             this.currentTurnId = message.turn_id;
             console.log(`Setting current turn ID to: ${message.turn_id} from text message`);
           }
+          this.options.onMessage(message);
           break;
-        }
+
         case 'response.data':
           console.log('received response.data', message);
           this.options.onDataMessage(message);
           break;
+
+        case 'user.transcript':
+          console.log('received user.transcript', message);
+          this.options.onMessage(message);
+          break;
+
         default:
           console.warn('Unknown message type received:', message);
-          break;
       }
     } catch (error) {
       console.error('Error processing WebSocket message:', error);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,7 +63,7 @@ export interface ClientTriggerResponseAudioInterruptedMessage extends BaseLayerc
 
 // Layercode Server WebSocket Messages → Client Browser WebSocket Messages
 export interface ServerTurnMessage extends BaseLayercodeMessage {
-  type: 'turn.start' | 'turn.end';
+  type: 'turn.start';
   role: 'user' | 'assistant'; // Note assistant role events are not currently implemented
   // turn_id: string; // TODO refactor our agents to allow turn_id to be included here
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,7 +4,6 @@ export type LayercodeMessageType =
   | 'trigger.turn.start'
   | 'trigger.turn.end'
   | 'trigger.response.audio.replay_finished'
-  | 'trigger.response.audio.interrupted'
   | 'vad_events'
   | 'client.ready'
 
@@ -51,15 +50,6 @@ export interface ClientTriggerResponseAudioReplayFinishedMessage extends BaseLay
   type: 'trigger.response.audio.replay_finished';
   reason: 'completed';
   last_delta_id_played?: string;
-}
-
-export interface ClientTriggerResponseAudioInterruptedMessage extends BaseLayercodeMessage {
-  type: 'trigger.response.audio.interrupted';
-  playback_offset?: number;
-  interruption_context?: {
-    turn_id: string;
-    playback_offset_ms: number;
-  };
 }
 
 // Layercode Server WebSocket Messages → Client Browser WebSocket Messages
@@ -128,13 +118,7 @@ export type ServerMessage =
   | ServerResponseUserTranscriptDelta
   | ServerResponseUserTranscript;
 
-export type ClientMessage =
-  | ClientAudioMessage
-  | ClientTriggerTurnMessage
-  | ClientTriggerResponseAudioReplayFinishedMessage
-  | ClientTriggerResponseAudioInterruptedMessage
-  | ClientVadEventsMessage
-  | ClientReadyMessage;
+export type ClientMessage = ClientAudioMessage | ClientTriggerTurnMessage | ClientTriggerResponseAudioReplayFinishedMessage | ClientVadEventsMessage | ClientReadyMessage;
 
 // Union type for all possible messages
 export type LayercodeMessage = ClientMessage | ServerMessage;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,7 +13,8 @@ export type LayercodeMessageType =
   | 'response.audio'
   | 'response.text' // Text content for interruption tracking
   | 'response.data' // Webhook event forwarded by server to client
-  | 'user.transcript'; // Partial and/or final user transcript text as it's transcribed
+  | 'user.transcript.delta' // Partial user transcript text as it's transcribed
+  | 'user.transcript'; // Final user transcript text at end of user turn
 
 // // Webhook → Server SSE
 // | 'response.tts'
@@ -87,9 +88,15 @@ export interface ServerResponseDataMessage extends BaseLayercodeMessage {
   turn_id: string;
 }
 
+export interface ServerResponseUserTranscriptDelta extends BaseLayercodeMessage {
+  type: 'user.transcript.delta';
+  content: string;
+  turn_id: string;
+}
+
 export interface ServerResponseUserTranscript extends BaseLayercodeMessage {
   type: 'user.transcript';
-  content: any; // {'partial': 'text from is_final', 'final': 'accumulated is_final msgs sent as final transcript to webhook'};
+  content: string;
   turn_id: string;
 }
 // // Webhook Response SSE Messages → Layercode Server
@@ -113,7 +120,13 @@ export interface ServerResponseUserTranscript extends BaseLayercodeMessage {
 // Create a discriminated union to differentiate between webhook and server messages
 // export type WebhookMessage = WebhookResponseTTSMessage | WebhookResponseDataMessage | ResponseEndMessage;
 
-export type ServerMessage = ServerTurnMessage | ServerResponseAudioMessage | ServerResponseTextMessage | ServerResponseDataMessage | ServerResponseUserTranscript;
+export type ServerMessage =
+  | ServerTurnMessage
+  | ServerResponseAudioMessage
+  | ServerResponseTextMessage
+  | ServerResponseDataMessage
+  | ServerResponseUserTranscriptDelta
+  | ServerResponseUserTranscript;
 
 export type ClientMessage =
   | ClientAudioMessage

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,8 +9,7 @@ export type LayercodeMessageType =
   | 'client.ready'
 
   // Server → Client WebSocket
-  | 'turn.start' // Not currently implemented
-  | 'turn.end' // Not currently implemented
+  | 'turn.start'
   | 'response.audio'
   | 'response.text' // Text content for interruption tracking
   | 'response.data' // Webhook event forwarded by server to client

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -90,7 +90,7 @@ export interface ServerResponseDataMessage extends BaseLayercodeMessage {
 
 export interface ServerResponseUserTranscript extends BaseLayercodeMessage {
   type: 'user.transcript';
-  content: any;
+  content: any; // {'partial': 'text from is_final', 'final': 'accumulated is_final msgs sent as final transcript to webhook'};
   turn_id: string;
 }
 // // Webhook Response SSE Messages → Layercode Server

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,7 +13,8 @@ export type LayercodeMessageType =
   | 'turn.end' // Not currently implemented
   | 'response.audio'
   | 'response.text' // Text content for interruption tracking
-  | 'response.data'; // Webhook event forwarded by server to client
+  | 'response.data' // Webhook event forwarded by server to client
+  | 'user.transcript'; // Partial and/or final user transcript text as it's transcribed
 
 // // Webhook → Server SSE
 // | 'response.tts'
@@ -87,6 +88,11 @@ export interface ServerResponseDataMessage extends BaseLayercodeMessage {
   turn_id: string;
 }
 
+export interface ServerResponseUserTranscript extends BaseLayercodeMessage {
+  type: 'user.transcript';
+  content: any;
+  turn_id: string;
+}
 // // Webhook Response SSE Messages → Layercode Server
 // export interface WebhookResponseTTSMessage extends BaseLayercodeMessage {
 //   type: 'response.tts';
@@ -108,7 +114,7 @@ export interface ServerResponseDataMessage extends BaseLayercodeMessage {
 // Create a discriminated union to differentiate between webhook and server messages
 // export type WebhookMessage = WebhookResponseTTSMessage | WebhookResponseDataMessage | ResponseEndMessage;
 
-export type ServerMessage = ServerTurnMessage | ServerResponseAudioMessage | ServerResponseTextMessage | ServerResponseDataMessage;
+export type ServerMessage = ServerTurnMessage | ServerResponseAudioMessage | ServerResponseTextMessage | ServerResponseDataMessage | ServerResponseUserTranscript;
 
 export type ClientMessage =
   | ClientAudioMessage


### PR DESCRIPTION
handle new sever>client user.transcript event which includes the is_final transcript parts from the pipeline 
add onMessage cb that receives all events aparts from response.data and audio

Also see companion react-sdk PR 

Do release after merging